### PR TITLE
libc: fix for macOS build

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -4,7 +4,11 @@ CRT = crt0.o
 all: libc.a $(CRT)
 
 libc.a: $(OBJ)
+ifneq ($(OBJ),)
 	ar rc libc.a $(OBJ)
+else
+	touch libc.a
+endif
 
 %.o: %.s
 	../as68/as68 $^


### PR DESCRIPTION
In macOS, `ar rc libc.a` fails if no objects specified.