### PR TITLE
Fix inclusion of string.h

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -1,7 +1,6 @@
 #ifndef __STRING_H
 #define __STRING_H
 
-#include <types.h>
 #include <stddef.h>
 
 /* Only a small subset so far */


### PR DESCRIPTION
string.h is trying to include types.h, which is not present in the compiler header files, causing a pre-compilation error.

string.h only needs size_t, so stddef.h only is needed.