### PR TITLE
Fix inclusion of ctype.h

### DIFF
--- a/include/ctype.h
+++ b/include/ctype.h
@@ -3,8 +3,6 @@
 #ifndef __CTYPE_H
 #define __CTYPE_H
 
-#include <stdint.h>
-
 extern int toupper(int __c);
 extern int tolower(int __c);
 


### PR DESCRIPTION
The presence of stdint.h inclusion in ctype.h is causing multiple definitions of size_t

Another fix would be to have only one definition of size_t (today in stdint.h and stddef.h). 

As ctype.h don't need types from stdint.h today, I removed it.