### PR TITLE
With the correct place for size_t, stddef.h needs stdint.h

### DIFF
--- a/include/stddef.h
+++ b/include/stddef.h
@@ -1,6 +1,8 @@
 #ifndef __STDDEF_H
 #define __STDDEF_H
 
+#include <stdint.h>
+
 typedef int ptrdiff_t;
 typedef char wchar_t;
 typedef unsigned int size_t;


### PR DESCRIPTION
Because of int16 usage to define size_t
